### PR TITLE
Update action.yaml - `node20`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -11,5 +11,5 @@ inputs:
     description: 'An authentication token (usually a GITHUB_TOKEN) authorised to fetch data from the `GitHub.com`. Only required if `version` is set to `latest`'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Otherwise, users get this warning in their pipelines:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: score-spec/setup-score@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```